### PR TITLE
Fix some optional configs are required by the checks

### DIFF
--- a/src/Generator.js
+++ b/src/Generator.js
@@ -174,7 +174,7 @@ export default class Generator {
     };
 
     for (const plugin of config.plugins) {
-      if (plugin.name === 'esdoc-standard-plugin') check(plugin.option.manual);
+      if (plugin.name === 'esdoc-standard-plugin' && plugin.option.manual) check(plugin.option.manual);
       if (plugin.name === 'esdoc-integrate-manual-plugin') check(plugin.option);
     }
   }
@@ -185,18 +185,18 @@ export default class Generator {
     };
 
     for (const plugin of config.plugins) {
-      if (plugin.name === 'esdoc-standard-plugin') check(plugin.option.test);
+      if (plugin.name === 'esdoc-standard-plugin' && plugin.option.test) check(plugin.option.test);
       if (plugin.name === 'esdoc-integrate-test-plugin') check(plugin.option);
     }
   }
 
   _checkBrandPlugin(config, repoDirPath) {
     const check = (option) => {
-      option.logo = this._checkPath(repoDirPath, option.logo);
+      if (option.logo) option.logo = this._checkPath(repoDirPath, option.logo);
     };
 
     for (const plugin of config.plugins) {
-      if (plugin.name === 'esdoc-standard-plugin') check(plugin.option.brand);
+      if (plugin.name === 'esdoc-standard-plugin' && plugin.option.brand) check(plugin.option.brand);
       if (plugin.name === 'esdoc-brand-plugin') check(plugin.option);
     }
   }


### PR DESCRIPTION
Hi, thank you for the great documentation generator & hosting service!

I fixed that some optional configs in `esdoc.json` are considered to be required by the checking process and it can cause unintended errors.
This may fix bugs reported in #17 and #20.
